### PR TITLE
chore(toolchain): add mise.toml and document dev setup

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,14 @@
+[tools]
+stylua = "2.4.1"
+
+[tasks.lint]
+description = "Run luacheck linter"
+run = "luacheck . --config .luacheckrc"
+
+[tasks.fmt]
+description = "Format Lua files with stylua"
+run = "stylua ."
+
+[tasks.fmt-check]
+description = "Check Lua formatting without modifying files"
+run = "stylua --check ."

--- a/README.md
+++ b/README.md
@@ -16,12 +16,32 @@ Download from the [Factorio Mod Portal](https://mods.factorio.com/) or place the
 
 ## Development
 
-```bash
-# Lint
-luacheck .
+### Prerequisites
 
-# Format check
-stylua --check .
+Install [mise](https://mise.jdx.dev/) for tool version management, then run:
+
+```bash
+mise install
+```
+
+This installs `stylua`. Additionally, install `luacheck` via Homebrew (macOS/Linux):
+
+```bash
+brew install luacheck
+```
+
+Or via LuaRocks:
+
+```bash
+luarocks install luacheck
+```
+
+### Tasks
+
+```bash
+mise run lint       # luacheck linter
+mise run fmt        # format with stylua
+mise run fmt-check  # check formatting without modifying files
 ```
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please).

--- a/README.md
+++ b/README.md
@@ -16,27 +16,13 @@ Download from the [Factorio Mod Portal](https://mods.factorio.com/) or place the
 
 ## Development
 
-### Prerequisites
-
-Install [mise](https://mise.jdx.dev/) for tool version management, then run:
+Install [mise](https://mise.jdx.dev/), then:
 
 ```bash
-mise install
+mise install  # installs stylua
 ```
 
-This installs `stylua`. Additionally, install `luacheck` via Homebrew (macOS/Linux):
-
-```bash
-brew install luacheck
-```
-
-Or via LuaRocks:
-
-```bash
-luarocks install luacheck
-```
-
-### Tasks
+Install `luacheck` via your package manager (`brew install luacheck`, `apt install lua-check`, or `luarocks install luacheck`).
 
 ```bash
 mise run lint       # luacheck linter


### PR DESCRIPTION
## What

- Adds `.mise.toml` with `stylua 2.4.1` pinned via mise
- Adds mise tasks: `lint`, `fmt`, `fmt-check`
- Updates README Development section with install instructions for `stylua` (via mise) and `luacheck` (via brew/luarocks)

## Why

Pins tool versions for reproducible local development and provides a single entry point (`mise run <task>`) for common dev commands.

## Risk

Low — no functional code changes, toolchain config only.