### PR TITLE
chore(docs): remove personal email from code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at timofey@heavywater.dev. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via a [GitHub issue](https://github.com/neojelll/Friction/issues). All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 


### PR DESCRIPTION
## What / Why

Removes personal email address from `CODE_OF_CONDUCT.md`. Replaces it with a link to GitHub Issues so abuse reports go through a maintainer-accessible channel instead of a private inbox.

## Risk

Docs-only change. No code affected.